### PR TITLE
fix off by one error in parse_ignore_groups

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -61,7 +61,6 @@ impl Lexer {
         // Manage last token (should always be "}")
         if slice_start_index < current_index {
             let slice = &src[slice_start_index..current_index];
-            assert_eq!(slice, "}", "[Lexer] Invalid last char, should be '}}'");
             if slice != "}" {
                 return Err(LexerError::InvalidLastChar);
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -278,9 +278,8 @@ impl<'a> Parser<'a> {
                     self.consume_token_at(self.cursor); // Consume the opening bracket
                     self.consume_tokens_until_matching_bracket();
                 }
-                _ => {}
+                _ => {self.cursor += 1;}
             }
-            self.cursor += 1;
         }
     }
 }


### PR DESCRIPTION
Since we consume the token at the current cursor, the new token would also be at the current cursor. This is for my Issue #5 . I also removed assert found in #6 