### PR TITLE
Fix the bug of repeated serde in features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ opt-level = 3
 [dependencies]
 derivative = "2.2.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-
-[features]
-serde_support = ["serde"]

--- a/src/document.rs
+++ b/src/document.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fs;
 use std::io::Read;
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::header::RtfHeader;
@@ -10,7 +10,7 @@ use crate::lexer::Lexer;
 use crate::parser::{Parser, StyleBlock};
 
 #[derive(Debug, Default, Clone, PartialEq)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct RtfDocument {
     pub header: RtfHeader,
     pub body: Vec<StyleBlock>,

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::paragraph::Paragraph;
@@ -24,7 +24,7 @@ pub type StyleSheet = HashMap<StyleRef, Style>;
 
 /// Style for the StyleSheet
 #[derive(Hash, Default, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Style {
     /// The style attributes
     painter: Painter,
@@ -34,7 +34,7 @@ pub struct Style {
 
 /// Information about the document, including references to fonts & styles
 #[derive(Default, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct RtfHeader {
     pub character_set: CharacterSet,
     pub font_table: FontTable,
@@ -43,7 +43,7 @@ pub struct RtfHeader {
 }
 
 #[derive(Hash, Default, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Font {
     pub name: String,
     pub character_set: u8,
@@ -51,7 +51,7 @@ pub struct Font {
 }
 
 #[derive(Hash, Default, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Color {
     pub red: u8,
     pub green: u8,
@@ -60,7 +60,7 @@ pub struct Color {
 
 #[allow(dead_code)]
 #[derive(Debug, PartialEq, Default, Clone, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum CharacterSet {
     #[default]
     Ansi,
@@ -81,7 +81,7 @@ impl CharacterSet {
 }
 
 #[allow(dead_code)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Hash, Clone, Default)]
 pub enum FontFamily {
     #[default]

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -1,12 +1,12 @@
 /// Define the paragraph related structs and enums
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::tokens::ControlWord;
 
 #[derive(Debug, Default, Clone, PartialEq, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Paragraph {
     pub alignment: Alignment,
     pub spacing: Spacing,
@@ -16,7 +16,7 @@ pub struct Paragraph {
 
 /// Alignement of a paragraph (left, right, center, justify)
 #[derive(Debug, Default, Clone, Copy, PartialEq, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Alignment {
     #[default]
     LeftAligned, // \ql
@@ -39,7 +39,7 @@ impl From<&ControlWord<'_>> for Alignment {
 
 /// The vertical margin before / after a block of text
 #[derive(Debug, Default, Clone, PartialEq, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Spacing {
     pub before: i32,
     pub after: i32,
@@ -48,7 +48,7 @@ pub struct Spacing {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum SpaceBetweenLine {
     Value(i32),
     #[default]
@@ -72,7 +72,7 @@ impl From<i32> for SpaceBetweenLine {
 
 // This struct can not be an enum because left-indent and right-ident can both be defined at the same time
 #[derive(Default, Debug, Clone, PartialEq, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Indentation {
     pub left: i32,
     pub right: i32,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::{fmt, mem};
 
 use derivative::Derivative;
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::document::RtfDocument;
@@ -21,7 +21,7 @@ macro_rules! header_control_word {
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct StyleBlock {
     pub painter: Painter,
     pub paragraph: Paragraph,
@@ -29,7 +29,7 @@ pub struct StyleBlock {
 }
 
 #[derive(Derivative, Debug, Clone, PartialEq, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derivative(Default)]
 pub struct Painter {
     pub color_ref: ColorRef,


### PR DESCRIPTION
<img width="244" alt="image" src="https://github.com/d0rianb/rtf-parser/assets/32771265/9ecaef62-3d6f-4121-802f-f2f178dee0b5">

```
[dependencies]
serde = { version = "1.0", optional = true, features = ["derive"] }

[features]
serde_support = ["serde"]
```
I deleted the feature of serde_spport and kept serde