### PR TITLE
Hide WASM JS bindings behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ inherits = "dev"
 opt-level = 0
 debug = true
 
+[features]
+default = ["jsbindings"]
+jsbindings = ["dep:wasm-bindgen", "dep:tsify"]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 
 #[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2"
-tsify = "0.4.5"
-
-
+wasm-bindgen = { version = "0.2", optional = true }
+tsify = { version = "0.4.5", optional = true }

--- a/src/document.rs
+++ b/src/document.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::Read;
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "jsbindings")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::header::RtfHeader;
@@ -10,13 +11,13 @@ use crate::lexer::Lexer;
 use crate::parser::{Parser, StyleBlock};
 
 // Interface to WASM to be used in JS
-#[wasm_bindgen]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen)]
 pub fn parse_rtf(rtf: String) -> RtfDocument {
     return RtfDocument::try_from(rtf).unwrap();
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen(getter_with_clone))]
 pub struct RtfDocument {
     pub header: RtfHeader,
     pub body: Vec<StyleBlock>,

--- a/src/header.rs
+++ b/src/header.rs
@@ -36,8 +36,7 @@ pub struct Style {
 
 /// Information about the document, including references to fonts & styles
 #[derive(Default, Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "jsbindings", derive(Tsify))]
-#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "jsbindings", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct RtfHeader {
     pub character_set: CharacterSet,
     pub font_table: FontTable,
@@ -63,8 +62,7 @@ pub struct Color {
 
 #[allow(dead_code)]
 #[derive(Debug, PartialEq, Default, Clone, Hash, Deserialize, Serialize)]
-#[cfg_attr(feature = "jsbindings", derive(Tsify))]
-#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "jsbindings", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub enum CharacterSet {
     #[default]
     Ansi,
@@ -86,8 +84,7 @@ impl CharacterSet {
 
 #[allow(dead_code)]
 #[derive(Debug, PartialEq, Hash, Clone, Default, Deserialize, Serialize)]
-#[cfg_attr(feature = "jsbindings", derive(Tsify))]
-#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "jsbindings", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub enum FontFamily {
     #[default]
     Nil,

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "jsbindings")]
 use tsify::Tsify;
+#[cfg(feature = "jsbindings")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::paragraph::Paragraph;
@@ -33,8 +35,9 @@ pub struct Style {
 }
 
 /// Information about the document, including references to fonts & styles
-#[derive(Default, Debug, Clone, PartialEq, Deserialize, Serialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "jsbindings", derive(Tsify))]
+#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct RtfHeader {
     pub character_set: CharacterSet,
     pub font_table: FontTable,
@@ -43,7 +46,7 @@ pub struct RtfHeader {
 }
 
 #[derive(Hash, Default, Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen(getter_with_clone))]
 pub struct Font {
     pub name: String,
     pub character_set: u8,
@@ -51,7 +54,7 @@ pub struct Font {
 }
 
 #[derive(Hash, Default, Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen)]
 pub struct Color {
     pub red: u8,
     pub green: u8,
@@ -59,8 +62,9 @@ pub struct Color {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, PartialEq, Default, Clone, Hash, Deserialize, Serialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Debug, PartialEq, Default, Clone, Hash, Deserialize, Serialize)]
+#[cfg_attr(feature = "jsbindings", derive(Tsify))]
+#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum CharacterSet {
     #[default]
     Ansi,
@@ -81,8 +85,9 @@ impl CharacterSet {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, PartialEq, Hash, Clone, Default, Deserialize, Serialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Debug, PartialEq, Hash, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "jsbindings", derive(Tsify))]
+#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum FontFamily {
     #[default]
     Nil,

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -1,12 +1,15 @@
 /// Define the paragraph related structs and enums
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "jsbindings")]
 use tsify::Tsify;
+#[cfg(feature = "jsbindings")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::tokens::ControlWord;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Hash, Deserialize, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen)]
 pub struct Paragraph {
     pub alignment: Alignment,
     pub spacing: Spacing,
@@ -15,8 +18,9 @@ pub struct Paragraph {
 }
 
 /// Alignement of a paragraph (left, right, center, justify)
-#[derive(Debug, Default, Clone, Copy, PartialEq, Hash, Deserialize, Serialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(feature = "jsbindings", derive(Tsify))]
+#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Alignment {
     #[default]
     LeftAligned, // \ql
@@ -39,7 +43,7 @@ impl From<&ControlWord<'_>> for Alignment {
 
 /// The vertical margin before / after a block of text
 #[derive(Debug, Default, Clone, Copy, PartialEq, Hash, Deserialize, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen)]
 pub struct Spacing {
     pub before: i32,
     pub after: i32,
@@ -47,8 +51,9 @@ pub struct Spacing {
     pub line_multiplier: i32,
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Hash, Deserialize, Serialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(feature = "jsbindings", derive(Tsify))]
+#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum SpaceBetweenLine {
     Value(i32),
     #[default]
@@ -72,7 +77,7 @@ impl From<i32> for SpaceBetweenLine {
 
 // This struct can not be an enum because left-indent and right-ident can both be defined at the same time
 #[derive(Default, Debug, Clone, Copy, PartialEq, Hash, Deserialize, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen)]
 pub struct Indentation {
     pub left: i32,
     pub right: i32,

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -19,8 +19,7 @@ pub struct Paragraph {
 
 /// Alignement of a paragraph (left, right, center, justify)
 #[derive(Debug, Default, Clone, Copy, PartialEq, Hash, Deserialize, Serialize)]
-#[cfg_attr(feature = "jsbindings", derive(Tsify))]
-#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "jsbindings", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Alignment {
     #[default]
     LeftAligned, // \ql
@@ -52,8 +51,7 @@ pub struct Spacing {
 }
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Hash, Deserialize, Serialize)]
-#[cfg_attr(feature = "jsbindings", derive(Tsify))]
-#[cfg_attr(feature = "jsbindings", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "jsbindings", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub enum SpaceBetweenLine {
     Value(i32),
     #[default]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::{fmt, mem};
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "jsbindings")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::document::RtfDocument;
@@ -20,7 +21,7 @@ macro_rules! header_control_word {
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Deserialize, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen(getter_with_clone))]
 pub struct StyleBlock {
     pub painter: Painter,
     pub paragraph: Paragraph,
@@ -28,7 +29,7 @@ pub struct StyleBlock {
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Deserialize, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "jsbindings", wasm_bindgen)]
 pub struct Painter {
     pub color_ref: ColorRef,
     pub font_ref: FontRef,


### PR DESCRIPTION
This allows building a WASM binary without the JS bindings and their corresponding imports that can be used in a non-JS environment.

See #19 for an explanation of why this is desirable. I have verified that this approach allows for producing binaries with and without JS bindings and it should maintain the current behavior for existing users; There might be other ways to achieve this.