### PR TITLE
Fix lexer::scan() and utils::impl MyStrExt for &str 

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -47,7 +47,7 @@ impl Lexer {
         let mut slice_start_index = 0;
         let mut previous_char = ' ';
     
-        // Работаем с безопасными UTF-8 индексами
+        // Working with safe UTF-8 indices
         for (current_index, c) in src.char_indices() {
             match c {
                 // TODO: Handle char over code 127 for escaped chars
@@ -55,7 +55,7 @@ impl Lexer {
                 '{' | '}' | '\\' | '\n' if previous_char == '\\' => {}
                 '{' | '}' | '\\' | '\n' => {
                     if slice_start_index < current_index {
-                        // Выделяем корректный UTF-8 срез
+                        // Extract a valid UTF-8 slice
                         let slice = &src[slice_start_index..current_index];
                         let slice_tokens = Self::tokenize(slice)?;
                         tokens.extend_from_slice(&slice_tokens);
@@ -67,7 +67,7 @@ impl Lexer {
             previous_char = c;
         }
     
-        // Обработка последнего токена
+        // Handling the last token
         if slice_start_index < src.len() {
             let slice = &src[slice_start_index..];
             if slice != "}" {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,34 +6,20 @@ pub trait StrUtils {
 
 impl StrUtils for str {
     // Split the string at the first whitespace
-    // ex : split_first_whitespace("\b I'm a bold string") -> ("\b", "I'm a bold string")
     fn split_first_whitespace(&self) -> (&str, &str) {
-        let mut first_whitespace_index = 0;
-
-        let len = self.len();
-        let bytes = self.as_bytes();
-        let mut i = 0;
-        // Faster than an iterator
-        while i < len {
-            let c = bytes[i] as char;
-            i += 1;
-
+        for (i, c) in self.char_indices() {
             if c.is_whitespace() {
-                break;
-            } else {
-                first_whitespace_index += 1;
+                let first = &self[..i];
+                // +c.len_utf8() чтобы срез начинался после пробела
+                let second = &self[i + c.len_utf8()..];
+                return (first, second);
             }
         }
-        if first_whitespace_index > 0 && first_whitespace_index != self.len() {
-            return (&self[0..first_whitespace_index], &self[first_whitespace_index + 1..]);
-        } else {
-            return (self, "");
-        }
+        (self, "")
     }
 
     fn is_only_whitespace(&self) -> bool {
-        // TODO
-        false
+        self.chars().all(|c| c.is_whitespace())
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ impl StrUtils for str {
         for (i, c) in self.char_indices() {
             if c.is_whitespace() {
                 let first = &self[..i];
-                // +c.len_utf8() чтобы срез начинался после пробела
+                // +c.len_utf8() so that the slice starts after the whitespace
                 let second = &self[i + c.len_utf8()..];
                 return (first, second);
             }


### PR DESCRIPTION
Fix UTF-8 safety in string slicing

Problem:
The original code indexed &str using byte offsets (bytes[i] as char and slices like &s[a..b]), which breaks UTF-8 when multi-byte characters are present (e.g., Cyrillic). This caused panics like: `byte index N is not a char boundary`

Solution:

- Loops rewritten to use char_indices() so all slice indices always land on valid UTF-8 character boundaries.
- Slices computed safely with i and c.len_utf8().
- Functions scan() and split_first_whitespace() now handle Unicode correctly.
- Added is_only_whitespace() implemented via chars().all(|c| c.is_whitespace()).

Effect:
The library no longer panics on RTF containing Cyrillic or other multi-byte characters, while preserving correct behavior for ASCII.
